### PR TITLE
Remove token looking string

### DIFF
--- a/data/systemchecker-sample-configuration/system_checker.conf
+++ b/data/systemchecker-sample-configuration/system_checker.conf
@@ -11,6 +11,6 @@ files = /tmp/nr.out,/tmp/foo
 event_names = file-change,file-change
 
 [wavefront]
-api_key=013cf031-1613-4b58-8c3c-b62e77833b1a
-api_base=http://127.0.0.1:8080
+api_key=<YOUR WAVEFRONT API KEY>
+api_base=https://<YOUR WAVEFRONT INSTANCE>.wavefront.com
 


### PR DESCRIPTION
Update system_checker sample config to have placeholders for wavefront configuration settings.  This is to prevent the sample config from tripping security scanners and also is clearer to the user as the sample config file now matches the documentation.